### PR TITLE
Simplify quote()

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ exports.quote = function (xs) {
             return s.op.replace(/(.)/g, '\\$1');
         }
         else if (/["\s]/.test(s) && !/'/.test(s)) {
-            return "'" + s.replace(/(['\\])/g, '\\$1') + "'";
+            return "'" + s.replace(/([\\])/g, '\\$1') + "'";
         }
         else if (/["'\s]/.test(s)) {
             return '"' + s.replace(/(["\\$`(){}!#&*|])/g, '\\$1') + '"';


### PR DESCRIPTION
In this chunk of code:

``` JavaScript
else if (/["\s]/.test(s) && !/'/.test(s)) {
   return "'" + s.replace(/(['\\])/g, '\\$1') + "'";
}
```

You may remove the `'` in the replace since you already tested that it is not contained in s (`!/'/.test(s)`)
