### PR TITLE
Fix broken quote() with special chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,10 @@ exports.quote = function (xs) {
             return "'" + s.replace(/(['\\])/g, '\\$1') + "'";
         }
         else if (/["'\s]/.test(s)) {
-            return '"' + s.replace(/(["\\$`(){}!#&*|])/g, '\\$1') + '"';
+            return '"' + s.replace(/(["\\$`!])/g, '\\$1') + '"';
         }
         else {
-            return String(s).replace(/([\\$`(){}!#&*|])/g, '\\$1');
+            return String(s).replace(/([\\$`()!#&*|])/g, '\\$1');
         }
     }).join(' ');
 };

--- a/test/quote.js
+++ b/test/quote.js
@@ -12,6 +12,11 @@ test('quote', function (t) {
         '\\$ \\` "\'"'
     );
     t.equal(quote([]), '');
+    t.equal(quote(["a\nb"]), "'a\nb'");
+    t.equal(quote([' #(){}*|][!']), "' #(){}*|][!'");
+    t.equal(quote(["'#(){}*|][!"]), '"\'#(){}*|][\\!"');
+    t.equal(quote(["X#(){}*|][!"]), "X\\#\\(\\){}\\*\\|][\\!");
+    t.equal(quote(["a\n#\nb"]), "'a\n#\nb'");
     t.equal(quote([ 'a', 1, true, false ]), 'a 1 true false');
     t.equal(quote([ 'a', 1, null, undefined ]), 'a 1 null undefined');
     t.end();


### PR DESCRIPTION
Add some failing tests and fix them

I noticed that `'echo ' + quote(["'#"])` => `echo "\'\#"`
which produces: `\'\#` when run in bash, which is wrong.

We are escaping lots of things inside double-quotes that we don't need
to, which ends up including the \ before each escaped char.