### PR TITLE
Braces: escape them when the string isn't quoted

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ exports.quote = function (xs) {
             return '"' + s.replace(/(["\\$`!])/g, '\\$1') + '"';
         }
         else {
-            return String(s).replace(/([\\$`()!#&*|])/g, '\\$1');
+            return String(s).replace(/([\\$`(){}!#&*|])/g, '\\$1');
         }
     }).join(' ');
 };

--- a/test/quote.js
+++ b/test/quote.js
@@ -15,7 +15,7 @@ test('quote', function (t) {
     t.equal(quote(["a\nb"]), "'a\nb'");
     t.equal(quote([' #(){}*|][!']), "' #(){}*|][!'");
     t.equal(quote(["'#(){}*|][!"]), '"\'#(){}*|][\\!"');
-    t.equal(quote(["X#(){}*|][!"]), "X\\#\\(\\){}\\*\\|][\\!");
+    t.equal(quote(["X#(){}*|][!"]), "X\\#\\(\\)\\{\\}\\*\\|][\\!");
     t.equal(quote(["a\n#\nb"]), "'a\n#\nb'");
     t.equal(quote([ 'a', 1, true, false ]), 'a 1 true false');
     t.equal(quote([ 'a', 1, null, undefined ]), 'a 1 null undefined');


### PR DESCRIPTION
Pull #13 (my own) accidentally removed {} from the list of chars to
escape when the string wasn't already quoted at all.

In bash, `A{blah,bleh}` expands to `Ablah Ableh`, so `{}` definitely need
to be escaped when the whole string isn't quoted.

Thanks for noticing @glasser !
