### PR TITLE
Add Process Substitution parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,10 @@ exports.quote = function (xs) {
     }).join(' ');
 };
 
+// '<(' is process substitution operator and
+// can be parsed the same as control operator
 var CONTROL = '(?:' + [
-    '\\|\\|', '\\&\\&', ';;', '\\|\\&', '[&;()|<>]'
+    '\\|\\|', '\\&\\&', ';;', '\\|\\&', '\\<\\(', '[&;()|<>]'
 ].join('|') + ')';
 var META = '|&;()<> \\t';
 var BAREWORD = '(\\\\[\'"' + META + ']|[^\\s\'"' + META + '])+';

--- a/test/op.js
+++ b/test/op.js
@@ -52,6 +52,14 @@ test('double operators', function (t) {
         parse('beep;;boop|&byte'),
         [ 'beep', { op: ';;' }, 'boop', { op: '|&' }, 'byte' ]
     );
+    t.same(
+        parse('beep<(boop)'),
+        [ 'beep', { op: '<(' }, 'boop', { op: ')' } ]
+    );
+    t.same(
+        parse('beep<<(boop)'),
+        [ 'beep', { op: '<' }, { op: '<(' }, 'boop', { op: ')' } ]
+    );
     
     t.end();
 });


### PR DESCRIPTION
Currently, something like:

```
var xs = parse('echo <(ls)');
```

will be parsed as:

```
[ 'echo', { op: '<' }, { op: '(' }, 'ls', { op: ')' } ]
```

This is wrong since when '<(' is process substitution operator.

This commit add support for parsing process substitution operator by
adding '<(' to the set of control operators. After this commit:

```
var xs = parse('echo <(ls)');
```

give:

```
[ 'echo', { op: '<(' }, 'ls', { op: ')' } ]
```
