### PR TITLE
add escape option to .parse

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -50,6 +50,20 @@ output
 [ 'beep', '--boop=/home/robot' ]
 ```
 
+## parse with custom escape charcter
+
+``` js
+var parse = require('shell-quote').parse;
+var xs = parse('beep --boop="$PWD"', { PWD: '/home/robot' }, { escape: '^' });
+console.dir(xs);
+```
+
+output
+
+```
+[ 'beep', '--boop=/home/robot' ]
+```
+
 ## parsing shell operators
 
 ``` js

--- a/test/parse.js
+++ b/test/parse.js
@@ -17,6 +17,7 @@ test('parse shell commands', function (t) {
     t.same(parse('a\\ b"c d"\\ e f'), [ 'a bc d e', 'f' ]);
     t.same(parse('a\\ b"c d"\\ e\'f g\' h'), [ 'a bc d ef g', 'h' ]);
     t.same(parse("x \"bl'a\"'h'"), ['x', "bl'ah"])
-    
+    t.same(parse("x bl^'a^'h'", {}, { escape: '^'}), ['x', "bl'a'h"]);
+
     t.end();
 });


### PR DESCRIPTION
This will make node-shell-quote compatible with windows if you pass in `{escape: '^'}`