### PR TITLE
add comment parsing feature

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -78,6 +78,20 @@ output:
 [ 'beep', { op: '||' }, 'boop', { op: '>' }, '/byte' ]
 ```
 
+## parsing shell comment
+
+``` js
+var parse = require('shell-quote').parse;
+var xs = parse('beep > boop # > kaboom');
+console.dir(xs);
+```
+
+output:
+
+```
+[ 'beep', { op: '>' }, 'boop', { comment: '> kaboom' } ]
+```
+
 # methods
 
 ``` js

--- a/test/comment.js
+++ b/test/comment.js
@@ -1,0 +1,14 @@
+var test = require('tape');
+var parse = require('../').parse;
+
+test('comment', function (t) {
+    t.same(parse('beep#boop'), [ 'beep', { comment: 'boop' } ]);
+    t.same(parse('beep #boop'), [ 'beep', { comment: 'boop' } ]);
+    t.same(parse('beep # boop'), [ 'beep', { comment: 'boop' } ]);
+    t.same(parse('beep # > boop'), [ 'beep', { comment: '> boop' } ]);
+    t.same(parse('beep # "> boop"'), [ 'beep', { comment: '"> boop"' } ]);
+    t.same(parse('beep "#"'), [ 'beep', '#' ]);
+    t.same(parse('beep #"#"#'), [ 'beep', { comment: '"#"#' } ]);
+    t.same(parse('beep > boop # > foo'), [ 'beep', {op: '>'}, 'boop', { comment: '> foo' } ]);
+    t.end();
+});


### PR DESCRIPTION
[npm-script is whether it can run in child_process.spawn](https://github.com/59naga/npm-run-script/blob/v0.0.1/src/index.js#L28-L32), it has been validated using this module.

```js
var parse = require('shell-quote').parse;
var scripts = require('./package.json').scripts;
var spawn = require('child_process').spawn;

var parsedCommand = parse(scripts.copy);
var notShellCommand = parsedCommand.reduce((can, op) => can && typeof op === 'string', true);
if (notShellCommand) {
  var file = parsedCommand[0];
  var args = parsedCommand.slice(1);
  spawn(file, args, {stdio: 'inherit'}).on('exit', function(code) {
    process.exit(code);
  });
}
```

currently, the comment (`#`) will be handled as an argument. therefore, the following will fail.

```bash
echo '{"scripts":{"copy":"cp foo.js bar.js # this is comment"}}' > package.json
node index.js && echo 0 || echo 1
# usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvX] source_file target_file
#        cp [-R [-H | -L | -P]] [-fi | -n] [-apvX] source_file ... target_directory
# 1
```

The PR is intended to fix the problem.