### PR TITLE
Fix bug in comment parsing: only words starting with "#" are comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ exports.quote = function (xs) {
             return '"' + s.replace(/(["\\$`!])/g, '\\$1') + '"';
         }
         else {
-            return String(s).replace(/([#!"$&'()*,:;<=>?@\[\\\]^`{|}])/g, '\\$1'); 
+            return String(s).replace(/([#!"$&'()*,:;<=>?@\[\\\]^`{|}])/g, '\\$1');
         }
     }).join(' ');
 };
@@ -63,6 +63,10 @@ function parse (s, env, opts) {
     return map(match, function (s, j) {
         if (commented) {
             return;
+        }
+        if (s.charAt(0) === '#') {
+            commented = true;
+            return { comment: s.substr(1) + match.slice(j+1).join(' ') };
         }
         if (RegExp('^' + CONTROL + '$').test(s)) {
             return { op: s };
@@ -125,13 +129,6 @@ function parse (s, env, opts) {
             }
             else if (RegExp('^' + CONTROL + '$').test(c)) {
                 return { op: s };
-            }
-            else if (RegExp('^#$').test(c)) {
-                commented = true;
-                if (out.length){
-                    return [out, { comment: s.slice(i+1) + match.slice(j+1).join(' ') }];
-                }
-                return [{ comment: s.slice(i+1) + match.slice(j+1).join(' ') }];
             }
             else if (c === BS) {
                 esc = true;

--- a/test/comment.js
+++ b/test/comment.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var parse = require('../').parse;
 
 test('comment', function (t) {
-    t.same(parse('beep#boop'), [ 'beep', { comment: 'boop' } ]);
+    t.same(parse('beep#boop'), [ 'beep#boop' ]);
     t.same(parse('beep #boop'), [ 'beep', { comment: 'boop' } ]);
     t.same(parse('beep # boop'), [ 'beep', { comment: 'boop' } ]);
     t.same(parse('beep # > boop'), [ 'beep', { comment: '> boop' } ]);


### PR DESCRIPTION
Currently, a hashtag occurring in any non-quoted string is treated as the start of a comment.
However this should only apply to the start of a word; e.g. `echo foo#bar` prints `foo#bar`.

See also: http://pubs.opengroup.org/onlinepubs/007904875/utilities/xcu_chap02.html