### PR TITLE
fix: do not remove $ when env variable not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ function parse (s, env, opts) {
 
     function getVar (_, pre, key) {
         var r = typeof env === 'function' ? env(key) : env[key];
-        if (r === undefined) r = '';
+        if (r === undefined) r = '$';
 
         if (typeof r === 'object') {
             return pre + TOKEN + json.stringify(r) + TOKEN;

--- a/test/env.js
+++ b/test/env.js
@@ -10,6 +10,8 @@ test('expand environment variables', function (t) {
     t.same(parse('qrs"$zzz"wxy', { zzz: 'tuv' }), [ 'qrstuvwxy' ]);
     t.same(parse("qrs'$zzz'wxy", { zzz: 'tuv' }), [ 'qrs$zzzwxy' ]);
     t.same(parse("qrs${zzz}wxy"), [ 'qrswxy' ]);
+    t.same(parse("qrs$wxy $"), [ 'qrs', '$' ]);
+    t.same(parse('grep "xy$"'), [ 'grep', 'xy$' ]);
     t.same(parse("ab$x", { x: 'c' }), [ 'abc' ]);
     t.same(parse("ab\\$x", { x: 'c' }), [ 'ab$x' ]);
     t.same(parse("ab${x}def", { x: 'c' }), [ 'abcdef' ]);

--- a/test/quote.js
+++ b/test/quote.js
@@ -11,16 +11,16 @@ test('quote', function (t) {
         quote([ '$', '`', '\'' ]),
         '\\$ \\` "\'"'
     );
-    t.equal(quote([]), '');                                                                                                                                                                                                                                                                                                                   
-    t.equal(quote(["a\nb"]), "'a\nb'");                                                                                                                                                                                                                                                                                                       
-    t.equal(quote([' #(){}*|][!']), "' #(){}*|][!'");                                                                                                                                                                                                                                                                                         
-    t.equal(quote(["'#(){}*|][!"]), '"\'#(){}*|][\\!"');                                                                                                                                                                                                                                                                                      
-    t.equal(quote(["X#(){}*|][!"]), "X\\#\\(\\)\\{\\}\\*\\|\\]\\[\\!");                                                                                                                                                                                                                                                                       
-    t.equal(quote(["a\n#\nb"]), "'a\n#\nb'");                                                                                                                                                                                                                                                                                                 
-    t.equal(quote(['><;{}']), '\\>\\<\\;\\{\\}');                                                                                                                                                                                                                                                                                             
-    t.equal(quote([ 'a', 1, true, false ]), 'a 1 true false');                                                                                                                                                                                                                                                                                
-    t.equal(quote([ 'a', 1, null, undefined ]), 'a 1 null undefined');                                                                                                                                                                                                                                                                        
-    t.end();  
+    t.equal(quote([]), '');
+    t.equal(quote(["a\nb"]), "'a\nb'");
+    t.equal(quote([' #(){}*|][!']), "' #(){}*|][!'");
+    t.equal(quote(["'#(){}*|][!"]), '"\'#(){}*|][\\!"');
+    t.equal(quote(["X#(){}*|][!"]), "X\\#\\(\\)\\{\\}\\*\\|\\]\\[\\!");
+    t.equal(quote(["a\n#\nb"]), "'a\n#\nb'");
+    t.equal(quote(['><;{}']), '\\>\\<\\;\\{\\}');
+    t.equal(quote([ 'a', 1, true, false ]), 'a 1 true false');
+    t.equal(quote([ 'a', 1, null, undefined ]), 'a 1 null undefined');
+    t.end();
 });
 
 test('quote ops', function (t) {


### PR DESCRIPTION
If I have command like `grep "xy$"`, the dollar sign gets parsed as an environment variable.

Signed-off-by: Adrian Matejov <a.matejov@centrum.sk>