### PR TITLE
[#47] Fix quoting of exclamation points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.7.3
+* Fix `!` not being quoted correctly when present in a string that also contains `'`.
+
 ## 1.7.2
 * Fix a regression introduced in 1.6.3. This reverts the Windows path quoting fix. ([144e1c2](https://github.com/substack/node-shell-quote/commit/144e1c20cd57549a414c827fb3032e60b7b8721c))
 

--- a/index.js
+++ b/index.js
@@ -3,14 +3,11 @@ exports.quote = function (xs) {
         if (s && typeof s === 'object') {
             return s.op.replace(/(.)/g, '\\$1');
         }
-        else if (/["\s]/.test(s) && !/'/.test(s)) {
-            return "'" + s.replace(/(['\\])/g, '\\$1') + "'";
-        }
-        else if (/["'\s]/.test(s)) {
-            return '"' + s.replace(/(["\\$`!])/g, '\\$1') + '"';
+        else if (/^[a-zA-Z0-9_-]+$/.test(s)) {
+            return String(s);
         }
         else {
-            return String(s).replace(/([A-z]:)?([#!"$&'()*,:;<=>?@\[\\\]^`{|}])/g, '$1\\$2');
+            return "'" + String(s).replace(/'/, "'\\''") + "'"
         }
     }).join(' ');
 };

--- a/test/quote.js
+++ b/test/quote.js
@@ -2,25 +2,26 @@ var test = require('tape');
 var quote = require('../').quote;
 
 test('quote', function (t) {
-    t.equal(quote([ 'a', 'b', 'c d' ]), 'a b \'c d\'');
+    t.equal(quote([ 'a', 'b', 'c d' ]), "a b 'c d'");
     t.equal(
         quote([ 'a', 'b', "it's a \"neat thing\"" ]),
-        'a b "it\'s a \\"neat thing\\""'
+        "a b 'it'\\''s a \"neat thing\"'"
     );
     t.equal(
         quote([ '$', '`', '\'' ]),
-        '\\$ \\` "\'"'
+        "'$' '`' ''\\'''"
     );
     t.equal(quote([]), '');
     t.equal(quote(["a\nb"]), "'a\nb'");
     t.equal(quote([' #(){}*|][!']), "' #(){}*|][!'");
-    t.equal(quote(["'#(){}*|][!"]), '"\'#(){}*|][\\!"');
-    t.equal(quote(["X#(){}*|][!"]), "X\\#\\(\\)\\{\\}\\*\\|\\]\\[\\!");
+    t.equal(quote(["'#(){}*|][!"]), "''\\''#(){}*|][!'");
+    t.equal(quote(["X#(){}*|][!"]), "'X#(){}*|][!'");
     t.equal(quote(["a\n#\nb"]), "'a\n#\nb'");
-    t.equal(quote(['><;{}']), '\\>\\<\\;\\{\\}');
+    t.equal(quote(['><;{}']), "'><;{}'");
     t.equal(quote([ 'a', 1, true, false ]), 'a 1 true false');
     t.equal(quote([ 'a', 1, null, undefined ]), 'a 1 null undefined');
-    t.equal(quote([ 'a\\x' ]), 'a\\\\x');
+    t.equal(quote([ 'a\\x' ]), "'a\\x'");
+    t.equal(quote(["This isn't OK!"]), "'This isn'\\''t OK!'");
     t.end();
 });
 


### PR DESCRIPTION
Closes #47.

This also generally simplifies the `quote()` implementation by using a simpler strategy for escaping single quotes.